### PR TITLE
Introducing Rescaling to BertScore ✨

### DIFF
--- a/src/moonshot/data/metrics/bertscore.py
+++ b/src/moonshot/data/metrics/bertscore.py
@@ -21,6 +21,7 @@ class BertScore:
             output_response,
             targets,
             lang="en",
+            rescale_with_baseline=True
         )
 
         avg_scores = [s.mean(dim=0) for s in score]

--- a/src/moonshot/data/prompt-templates/legal-term-template.json
+++ b/src/moonshot/data/prompt-templates/legal-term-template.json
@@ -1,0 +1,5 @@
+{
+    "name": "Legal Term",
+    "description": "The template used for legal term dataset.",
+    "template": "Explain this term that is used in the legal context: {{ prompt }}\nA: "
+}

--- a/src/moonshot/data/prompt-templates/question-answer-template2.json
+++ b/src/moonshot/data/prompt-templates/question-answer-template2.json
@@ -1,0 +1,5 @@
+{
+    "name": "question-answer-template2",
+    "description": "This is a common template used for open-ended benchmarks.",
+    "template": "Q: \"{{ prompt }}\"\nA:"
+}

--- a/src/moonshot/data/recipes/sg-legal-glossary.json
+++ b/src/moonshot/data/recipes/sg-legal-glossary.json
@@ -5,7 +5,7 @@
     ],
     "dataset": "sg-legal-glossary",
     "prompt_templates": [
-        "question-answer-template1"
+        "question-answer-template2"
     ],
     "metrics": [
         "bertscore"

--- a/src/moonshot/data/recipes/sg-legal-glossary.json
+++ b/src/moonshot/data/recipes/sg-legal-glossary.json
@@ -5,7 +5,7 @@
     ],
     "dataset": "sg-legal-glossary",
     "prompt_templates": [
-        "question-answer-template2"
+        "legal-term-template"
     ],
     "metrics": [
         "bertscore"

--- a/src/moonshot/data/recipes/sg-university-tutorial-questions-legal.json
+++ b/src/moonshot/data/recipes/sg-university-tutorial-questions-legal.json
@@ -5,7 +5,7 @@
     ],
     "dataset": "sg-university-tutorial-questions-legal",
     "prompt_templates": [
-        "question-answer-template1"
+        "question-answer-template2"
     ],
     "metrics": [
         "bertscore"


### PR DESCRIPTION
### Why This Matters?

For most cases, BERTScore is often between 0.8 and 0.95. This makes it harder to interpret and work with, especially if we want to compare BERTScore among the models.

### What was Done?

We enabled the rescaling option when BERTScore is called. This rescaling will be done through a simple linear transformation to a more intuitive range.

### Other stuffs

We have also updated our legal dataset with a new prompt template to make it more precise.

*Note that the range of BERTScore is between -1 and 1. Hence, in some cases, we may encounter negative values. This means that the reference and candidate are semantically very different from each other.*