### PR TITLE
Introducing RelaxStrMatch ✨

### DIFF
--- a/src/moonshot/data/cookbooks/legal-summarisation.json
+++ b/src/moonshot/data/cookbooks/legal-summarisation.json
@@ -7,10 +7,7 @@
         "cause-and-effect-one-sentence",
         "cause-and-effect-two-sentence",
         "contextual-parametric-knowledge-conflicts",
-        "coqa-conversational-qna",
         "gre-reading-comprehension",
-        "squad-shifts-tnf",
-        "sg-legal-glossary",
-        "sg-university-tutorial-questions-legal"
+        "squad-shifts-tnf"
     ]
 }

--- a/src/moonshot/data/metrics/exactstrmatch.py
+++ b/src/moonshot/data/metrics/exactstrmatch.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any
+import re
 
 from moonshot.src.utils.timeit import timeit
 
@@ -11,7 +12,6 @@ class ExactStrMatch:
     """
     ExactStrMatch will compare the output from language model with the expected target.
     """
-
     @staticmethod
     @timeit
     def get_results(
@@ -34,6 +34,24 @@ class ExactStrMatch:
         total = len(predicted_results)
 
         for idx, (result, target) in enumerate(zip(predicted_results, targets)):
-            if result == target:
-                correct += 1
+            # remove symbols and space
+            result = re.sub(r'[^\w]', '', result.rstrip()).replace(' ', '')
+            result = result.lower()
+
+            # To support benchmarks with multiple possible answers
+            if type(target) == list:
+                for each_item in target:
+                    each_item = re.sub(r'[^\w]', '', each_item.rstrip()).replace(' ', '')
+                    each_item = each_item.lower()
+
+                    if result == each_item:
+                        correct += 1
+                        break
+            else:
+                target = re.sub(r'[^\w\s]', '', target.rstrip()).replace(' ', '')
+                target = target.lower()
+            
+                if result == target:
+                    correct += 1
+                
         return {"exact_str_match": float(correct / total)}

--- a/src/moonshot/data/metrics/relaxstrmatch.py
+++ b/src/moonshot/data/metrics/relaxstrmatch.py
@@ -8,9 +8,9 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-class ExactStrMatch:
+class RelaxStrMatch:
     """
-    ExactStrMatch will compare the output from language model with the expected target.
+    RelaxStrMatch will remove symbols and spaces before comparing the output from language model with the expected target.
     """
     @staticmethod
     @timeit
@@ -34,7 +34,24 @@ class ExactStrMatch:
         total = len(predicted_results)
 
         for idx, (result, target) in enumerate(zip(predicted_results, targets)):
-           if result == target:
-                correct += 1
+            # remove symbols and space
+            result = re.sub(r'[^\w]', '', result.rstrip()).replace(' ', '')
+            result = result.lower()
+
+            # To support benchmarks with multiple possible answers
+            if type(target) == list:
+                for each_item in target:
+                    each_item = re.sub(r'[^\w]', '', each_item.rstrip()).replace(' ', '')
+                    each_item = each_item.lower()
+
+                    if result == each_item:
+                        correct += 1
+                        break
+            else:
+                target = re.sub(r'[^\w\s]', '', target.rstrip()).replace(' ', '')
+                target = target.lower()
+            
+                if result == target:
+                    correct += 1
                 
-        return {"exact_str_match": float(correct / total)}
+        return {"relax_str_match": float(correct / total)}

--- a/src/moonshot/data/recipes/analogical-similarity.json
+++ b/src/moonshot/data/recipes/analogical-similarity.json
@@ -8,6 +8,6 @@
         "analogical-similarity"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/auto-categorisation.json
+++ b/src/moonshot/data/recipes/auto-categorisation.json
@@ -8,6 +8,6 @@
         "auto-categorisation"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/cause-and-effect-one-sentence.json
+++ b/src/moonshot/data/recipes/cause-and-effect-one-sentence.json
@@ -8,6 +8,6 @@
         "cause-and-effect-one-sentence"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/cause-and-effect-two-sentence.json
+++ b/src/moonshot/data/recipes/cause-and-effect-two-sentence.json
@@ -8,6 +8,6 @@
         "cause-and-effect-two-sentence"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/contextual-parametric-knowledge-conflicts.json
+++ b/src/moonshot/data/recipes/contextual-parametric-knowledge-conflicts.json
@@ -8,6 +8,6 @@
         "contextual-parametric-knowledge-conflicts"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/gre-reading-comprehension.json
+++ b/src/moonshot/data/recipes/gre-reading-comprehension.json
@@ -8,6 +8,6 @@
         "gre-reading-comprehension"
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }

--- a/src/moonshot/data/recipes/squad-shifts-tnf.json
+++ b/src/moonshot/data/recipes/squad-shifts-tnf.json
@@ -1,13 +1,13 @@
 {
     "name": "squad-shifts-tnf",
-    "description": "Zero-shot reading comprehension on paragraphs and questions from squadshifts",
+    "description": "Zero-shot reading comprehension on paragraphs and questions from squadshifts. Augmented to true/false statement.",
     "tags": [
     ],
     "dataset": "squad-shifts-tnf",
     "prompt_templates": [
-        "squad-shifts"
+
     ],
     "metrics": [
-        "exactstrmatch"
+        "relaxstrmatch"
     ]
 }


### PR DESCRIPTION
### Why This Matters?

Some models may not return exact values (e.g. comes with a full stop, comes with break lines) as what we have requested in our prompt templates. While this may reflect that the model is unable to follow instruction, we may not want to penalise this behaviour in some situation - especially when we want to focus on the model's ability in producing correct answer (instead of the format of the output).

### What was Done?

We added a new metric - _RelaxStrMatch_. This metric removes symbols and spaces from predicted responses and ground truth values. 

### Other Matters

Updated some recipes and legal cookbook to use relax str match as it is more appropriate for certain use cases.