### PR TITLE
add the argument to execute the appropriate moonshot interface

### DIFF
--- a/moonshot/__main__.py
+++ b/moonshot/__main__.py
@@ -1,17 +1,26 @@
 import sys
+import warnings
 from moonshot.integrations.web_api import __main__ as web_api
+from moonshot.integrations.cli import __main__ as cli
 
 """
 Run the Moonshot application
 """
+# Setting the warnings to be ignored
+warnings.filterwarnings("ignore")
 
 def main():
-    if len(sys.argv) != 2:
+    if len(sys.argv) < 2:
         print("Invalid number of argument given.")
         sys.exit(1)
     option = sys.argv[1]
     if option == "web_api":
         web_api.start_app()
+    if option == "cli":
+        cli.start_app()
+    else: 
+        print("Unrecognized arguments. Please use web_api or cli")
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/moonshot/__main__.py
+++ b/moonshot/__main__.py
@@ -1,6 +1,5 @@
 import sys
 from moonshot.integrations.web_api import __main__ as web_api
-# from moonshot.integrations.cli import __main__ as cli
 
 """
 Run the Moonshot application
@@ -13,8 +12,6 @@ def main():
     option = sys.argv[1]
     if option == "web_api":
         web_api.start_app()
-    # elif option == "cli":
-    #     cli.start_app()
 
 if __name__ == "__main__":
     main()

--- a/moonshot/__main__.py
+++ b/moonshot/__main__.py
@@ -1,32 +1,20 @@
 import sys
-import warnings
-
-from moonshot.interfaces.cli.cli import CommandLineInterface
+from moonshot.integrations.web_api import __main__ as web_api
+# from moonshot.integrations.cli import __main__ as cli
 
 """
 Run the Moonshot application
 """
-# Setting the warnings to be ignored
-warnings.filterwarnings("ignore")
-
 
 def main():
-    cli_instance = CommandLineInterface()
-    if "interactive" in sys.argv:
-        # Run in interactive mode
-        cli_instance.debug = True
-        cli_instance.cmdloop("Starting moonshot interactive prompt...")
-    else:
-        # Run in non-interactive mode
-        arguments = sys.argv[1:]
-        if arguments:
-            arguments = f"{sys.argv[1]} "
-            for arg in sys.argv[2:]:
-                arguments += f'"{arg}" '
-            cli_instance.onecmd(arguments)
-        else:
-            cli_instance.onecmd("help")
-
+    if len(sys.argv) != 2:
+        print("Invalid number of argument given.")
+        sys.exit(1)
+    option = sys.argv[1]
+    if option == "web_api":
+        web_api.start_app()
+    # elif option == "cli":
+    #     cli.start_app()
 
 if __name__ == "__main__":
     main()

--- a/moonshot/integrations/cli/__main__.py
+++ b/moonshot/integrations/cli/__main__.py
@@ -1,0 +1,11 @@
+import sys
+
+def start_app():
+    #placeholder function
+    print("Hello World from CLI")
+    if "interactive" in sys.argv:
+        print("interactive argument received.")
+    
+
+if __name__ == "__main__":
+    start_app()

--- a/moonshot/integrations/web_api/__main__.py
+++ b/moonshot/integrations/web_api/__main__.py
@@ -13,7 +13,6 @@ def start_app():
     container: Container = Container()
     #use our own config.yml 
     config_file= dotenv_values().get("MS_WEB_API_CONFIG")
-    print(config_file)
     if config_file is None:
         container.config.from_default()
     else:


### PR DESCRIPTION
with this change, user can just execute the appropriate moonshot interface. 

if they wish to run web, they can execute by `python3 -m moonshot web_api`