### PR TITLE
add categories_excluded query param to cookbook web-api route

### DIFF
--- a/moonshot/integrations/web_api/routes/cookbook.py
+++ b/moonshot/integrations/web_api/routes/cookbook.py
@@ -59,6 +59,9 @@ def get_all_cookbooks(
     categories: Optional[str] = Query(
         None, description="Filter cookbooks by categories"
     ),
+    categories_excluded: Optional[str] = Query(
+        None, description="Filter out (exlude) cookbooks by categories"
+    ),
     count: bool = Query(False, description="Whether to include the count of recipes"),
     cookbook_service: CookbookService = Depends(Provide[Container.cookbook_service]),
 ) -> list[CookbookResponseModel]:
@@ -69,6 +72,7 @@ def get_all_cookbooks(
         ids (Optional[str]): A string to filter cookbooks by ids.
         tags (Optional[str]): A string to filter cookbooks by tags.
         categories (Optional[str]): A string to filter cookbooks by categories.
+        categories_excluded (Optional[str]): A string to filter out (exclude) cookbooks by categories.
         count (bool): A flag to decide if the count of recipes should be included.
         cookbook_service (CookbookService): The service layer responsible for retrieval logic.
 
@@ -82,7 +86,7 @@ def get_all_cookbooks(
     """
     try:
         cookbooks = cookbook_service.get_all_cookbooks(
-            tags=tags, categories=categories, count=count, ids=ids
+            tags=tags, categories=categories, count=count, ids=ids, categories_excluded=categories_excluded
         )
         return cookbooks
     except ServiceException as e:

--- a/moonshot/integrations/web_api/services/cookbook_service.py
+++ b/moonshot/integrations/web_api/services/cookbook_service.py
@@ -26,7 +26,7 @@ class CookbookService(BaseService):
 
     @exception_handler
     def get_all_cookbooks(
-        self, tags: str, categories: str, count: bool, ids: str | None = None
+        self, tags: str, categories: str, count: bool, ids: str | None = None, categories_excluded: str | None = None
     ) -> list[CookbookResponseModel]:
         """
         Retrieve all cookbooks, optionally filtered by tags and categories, and with prompt counts.
@@ -40,7 +40,7 @@ class CookbookService(BaseService):
         Returns:
             list[CookbookResponseModel]: A list of cookbook response models.
         """
-        cookbooks_list = []
+        cookbooks_list: list[CookbookResponseModel] = []
 
         if ids:
             cookbook_ids = ids.split(',')
@@ -51,17 +51,33 @@ class CookbookService(BaseService):
 
         for cookbook_dict in cookbooks:
             cookbook = CookbookResponseModel(**cookbook_dict)
-            if count:
-                cookbook.total_prompt_in_cookbook = get_total_prompt_in_cookbook(
-                    cookbook
-                )
+            
             if not tags and not categories:
-                cookbooks_list.append(cookbook)
+                if cookbook not in cookbooks_list:
+                    cookbooks_list.append(cookbook)
+                    if count:
+                        cookbook.total_prompt_in_cookbook = get_total_prompt_in_cookbook(
+                            cookbook
+                        )
+
             if tags and cookbooks_recipe_has_tags(tags, cookbook):
-                cookbooks_list.append(cookbook)
+                if cookbook not in cookbooks_list:
+                    cookbooks_list.append(cookbook)
+                    if count:
+                        cookbook.total_prompt_in_cookbook = get_total_prompt_in_cookbook(
+                            cookbook
+                        )
+
             if categories and cookbooks_recipe_has_categories(categories, cookbook):
                 if cookbook not in cookbooks_list:
                     cookbooks_list.append(cookbook)
+                    if count:
+                        cookbook.total_prompt_in_cookbook = get_total_prompt_in_cookbook(
+                            cookbook
+                        )
+
+            if categories_excluded and cookbooks_recipe_has_categories(categories_excluded, cookbook):
+                cookbooks_list.remove(cookbook)
 
         return cookbooks_list
 
@@ -152,6 +168,7 @@ def cookbooks_recipe_has_categories(categories: str, cookbook: Cookbook) -> bool
     Args:
         categories (str): The categories to check for in the cookbook's recipes.
         cookbook (Cookbook): The cookbook object containing the recipe IDs.
+        exclude_categories (str): The categories to exclude
 
     Returns:
         bool: True if any recipe in the cookbook has the specified categories, False otherwise.
@@ -164,6 +181,5 @@ def cookbooks_recipe_has_categories(categories: str, cookbook: Cookbook) -> bool
         if any(
             category in [rcat.lower() for rcat in recipe.categories]
             for category in categories_list):
-            # TODO - handle spaces in categories like 'Trust & Safety'
             return True
     return False


### PR DESCRIPTION
Add a filter parameter to exclude categories on get cookbooks route endpoint. This is useful for use cases like the `others` tab in cookbook selection